### PR TITLE
fix(README): update preview image URL to display correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Settings are applied in the following order of precedence:
 
 ## 📸 Live Preview
 
-![Preview]([https://drive.google.com/file/d/1KTXwRBcEkAqRKFXZMVP4XtSSh8uE1gDb/view](https://drive.google.com/file/d/1KTXwRBcEkAqRKFXZMVP4XtSSh8uE1gDb/view))
+![Preview](https://drive.usercontent.google.com/download?id=1KTXwRBcEkAqRKFXZMVP4XtSSh8uE1gDb)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Settings are applied in the following order of precedence:
 
 ## 📸 Live Preview
 
-![Preview](https://drive.google.com/file/d/1KTXwRBcEkAqRKFXZMVP4XtSSh8uE1gDb/view)
+![Preview]([https://drive.google.com/file/d/1KTXwRBcEkAqRKFXZMVP4XtSSh8uE1gDb/view](https://drive.google.com/file/d/1KTXwRBcEkAqRKFXZMVP4XtSSh8uE1gDb/view))
 
 ---
 


### PR DESCRIPTION
The previous image URL was broken. Replaced it with a working link so viewers can see the plugin preview properly in the README.